### PR TITLE
Add multiprocessing mode to game_random.py

### DIFF
--- a/game_random.py
+++ b/game_random.py
@@ -1,19 +1,16 @@
+import multiprocessing as mp
 import random
 import sys
 
 import game
 
 
-def main():
-    n = 5000
-
+def simulate(n):
+    if n == 0: yield 0, 0
     won = 0
     lost = 0
 
     for i in range(n):
-        print("\rGame #%d" % (i + 1), end='')
-        sys.stdout.flush()
-
         board = game.new_board()
 
         while True:
@@ -21,15 +18,71 @@ def main():
             game.add_cell(board)
 
             if game.is_board_won(board):
-                won += 1
+                yield 1, 0
                 break
 
             if game.is_board_lost(board):
-                lost += 1
+                yield 0, 1
                 break
+
+
+def simulate_batched(n, batch_size=50):
+    whole_batches = n // batch_size
+
+    for batch_idx in range(whole_batches):
+        won, lost = map(sum, zip(*simulate(batch_size)))
+        yield won, lost
+
+    won, lost = map(sum, zip(*simulate(n % batch_size)))
+    yield won, lost
+
+
+def simulate_mp_worker(n, q, batch_size):
+    for result in simulate_batched(n, batch_size):
+        q.put(result)
+
+
+def simulate_mp(n, p, batch_size):
+    won = 0
+    lost = 0
+
+    children = []
+    q = mp.Queue()
+
+    for p_idx in range(p):
+        work_here = n // p + (1 if p_idx < n % p else 0)
+        proc = mp.Process(target=simulate_mp_worker, args=(work_here, q, batch_size))
+        proc.start()
+        children.append(p)
+
+    while mp.active_children():
+        try:
+            yield q.get(timeout=3)
+        except:
+            # safe to ignore
+            pass
+
+
+def main(argv):
+    won = 0
+    lost = 0
+
+    simulation = simulate_batched(argv.n, argv.b) \
+            if argv.p == 1 else simulate_mp(argv.n, argv.p, argv.b)
+
+    for won_here, lost_here in simulation:
+        won += won_here
+        lost += lost_here
+        print("\rGame #%d: %d:%d" % (won + lost, won, lost), end='')
+        sys.stdout.flush()
 
     print("\n\nWin: %d, Lost: %d, Percent: %.1f" % (won, lost, (won / lost) * 100))
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-n', type=int, help='how many simulations to run', default=5000)
+    parser.add_argument('-p', type=int, help='parallelism for multiprocessing', default=1)
+    parser.add_argument('-b', type=int, help='how large each batch should be', default=50)
+    main(parser.parse_args())


### PR DESCRIPTION
Offers a speedup when simulating random games.

Example run:
```
Py2048 (master) $ time python3 game_random.py -n 1000 -p 8 -b 33
Game #1000: 0:1000
Win: 0, Lost: 1000, Percent: 0.0
real    0m31.605s
user    1m32.641s
sys     0m0.391s                                                                                                                                                                                                 

Py2048 (master) $ time python3 game_random.py -n 1000
Game #1000: 0:1000
Win: 0, Lost: 1000, Percent: 0.0
real    1m34.497s
user    1m27.125s
sys     0m0.969s
```